### PR TITLE
Require stack_master version 2 or above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+### Added
+
+- Usage documentation added to the readme ([#1]).
+
+### Changed
+
+- Require stack_master version 2 or above ([#2]).
+
 [Unreleased]: https://github.com/envato/stack_master-gpg_parameter_resolver/compare/v0.1.0...HEAD
+[#1]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/1
+[#2]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/2
 
 ## [0.1.0] - 2019-07-19
 ### Added

--- a/stack_master-gpg_parameter_resolver.gemspec
+++ b/stack_master-gpg_parameter_resolver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stack_master"
+  spec.add_dependency "stack_master", ">= 2"
   spec.add_dependency "dotgpg"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Before version 2 the GPG parameter resolver was included with `stack_master`.