### PR TITLE
Remove version restrictions on rake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Require stack_master version 2 or above ([#2]).
+- Require `stack_master` version 2 or above ([#2]).
+- Remove version restrictions on `rake` ([#3]).
 
 [Unreleased]: https://github.com/envato/stack_master-gpg_parameter_resolver/compare/v0.1.0...HEAD
 [#1]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/1
 [#2]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/2
+[#3]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/3
 
 ## [0.1.0] - 2019-07-19
 ### Added

--- a/stack_master-gpg_parameter_resolver.gemspec
+++ b/stack_master-gpg_parameter_resolver.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "stack_master", ">= 2"
   spec.add_dependency "dotgpg"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.8"
 end


### PR DESCRIPTION
Older versions of rake have a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-8130). Let's remove the rake version restrictions so devs can use a patched version.