### PR TITLE
Run CI on GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+---
+name: tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: RSpec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-- 2.4
-- 2.5
-- 2.6
-before_install:
-- gem update --system
-- gem install bundler -v '~> 2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Default git branch renamed to `main`.
+- CI build runs on GitHub Actions ([#4]).
+
 [Unreleased]: https://github.com/envato/stack_master-gpg_parameter_resolver/compare/v1.0.0...HEAD
+[#4]: https://github.com/envato/stack_master-gpg_parameter_resolver/pull/4
 
 ## [1.0.0] - 2020-03-04
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StackMaster::GpgParameterResolver
 
-[![Build Status](https://travis-ci.org/envato/stack_master-gpg_parameter_resolver.svg?branch=master)](https://travis-ci.org/envato/stack_master-gpg_parameter_resolver)
+[![Build Status](https://github.com/envato/stack_master-gpg_parameter_resolver/workflows/tests/badge.svg?branch=main)](https://github.com/envato/stack_master-gpg_parameter_resolver/actions?query=branch%3Amain+workflow%3Atests)
 
 Resolve [StackMaster] parameters from within GPG encrypted YAML files.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StackMaster::GpgParameterResolver
 
+[![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/stack_master-gpg_parameter_resolver/blob/main/LICENSE.txt)
+[![Gem Version](https://badge.fury.io/rb/stack_master-gpg_parameter_resolver.svg)](https://rubygems.org/gems/stack_master-gpg_parameter_resolver)
 [![Build Status](https://github.com/envato/stack_master-gpg_parameter_resolver/workflows/tests/badge.svg?branch=main)](https://github.com/envato/stack_master-gpg_parameter_resolver/actions?query=branch%3Amain+workflow%3Atests)
 
 Resolve [StackMaster] parameters from within GPG encrypted YAML files.


### PR DESCRIPTION
Migrate from Travis CI to [GitHub Actions](https://github.com/features/actions) for the CI build.